### PR TITLE
Fix remove_italics not having an effect

### DIFF
--- a/lua/ofirkai/init.lua
+++ b/lua/ofirkai/init.lua
@@ -20,8 +20,8 @@ end
 local function filter_hl_groups(config, hl_groups)
 	for _, colors in pairs(hl_groups) do
 		if config.remove_italics then
-			if colors.style == 'italic' then
-				colors.style = nil
+			if colors.italic then
+				colors.italic = false
 			end
 		end
 	end


### PR DESCRIPTION
It looks like remove_italics stopped working in 5b446a3394f28e1ba3ddb11dd46c3ca4343bd9d8 when configuration of italics moved from the `style` key to its own `italic` key. This change makes `remove_italics` edit the new `italic` key instead of the old `style` key.