### PR TITLE
Link `CurSearch` to `Search`

### DIFF
--- a/lua/ofirkai/design.lua
+++ b/lua/ofirkai/design.lua
@@ -138,6 +138,9 @@ M.hl_groups = function(scheme)
 		Search = {
 			bg = scheme.search_bg,
 		},
+		CurSearch = {
+			link = 'Search',
+		},
 		IncSearch = {
 			fg = scheme.inc_search_fg,
 			bg = scheme.inc_search_bg,


### PR DESCRIPTION
Neovim <0.10 links `CurSearch` to `Search`, this is not the case anymore in 0.10:
0.92:
<img width="924" alt="image" src="https://github.com/user-attachments/assets/9201ba54-8cb5-41e8-a121-ce2b2b41aac9">
0.10:
<img width="978" alt="image" src="https://github.com/user-attachments/assets/025d8df1-ab0d-49c9-88a1-898331b885f4">

This PR re-links it for now to restore the expected highlight colors.
Before relink:
<img width="275" alt="image" src="https://github.com/user-attachments/assets/c7e34b90-465c-4f50-8589-95ca751ff5bc">

After relink (same as current highlight in 0.92):
<img width="267" alt="image" src="https://github.com/user-attachments/assets/94f37a3b-c3c7-458a-ae57-8c81fb60e529">

