### PR TITLE
feat(extras): Ghostty themes for both schemes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Requires Neovim 0.8+
 	* [Winbars](#winbars)
 	* [Tab Lines](#tab-lines)
 	* [Others](#others)
+* [Terminals](#terminals)
+	* [Ghostty](#ghostty)
 * [Contributing](#contributing)
 ---
 
@@ -374,6 +376,27 @@ local lsp_signature_cfg = {
 
 ---
 </details>
+
+## Terminals
+Ports of the scheme to terminal emulators, so the shell around Neovim matches it.
+They live in [extras/](https://github.com/ofirgall/ofirkai.nvim/tree/master/extras).
+
+### Ghostty
+Copy the theme you use into Ghostty's theme directory and select it:
+```sh
+mkdir -p ~/.config/ghostty/themes
+cp extras/ghostty/ofirkai ~/.config/ghostty/themes/           # default scheme
+cp extras/ghostty/ofirkai-darkblue ~/.config/ghostty/themes/  # dark_blue theme
+```
+```ini
+# ~/.config/ghostty/config
+theme = ofirkai
+```
+The file name is the theme name, so keep the files extensionless. Reload with
+`Cmd/Ctrl+Shift+,`.
+
+Each file lists the handful of slots that are not a straight copy of the scheme
+(the ANSI bright row, and the accents that have no ANSI slot of their own).
 
 ## Full setup example
 [ui.lua](https://github.com/ofirgall/dotfiles/blob/master/editors/nvim/lua/plugins/ui.lua) from my dotfiles.

--- a/extras/ghostty/ofirkai
+++ b/extras/ghostty/ofirkai
@@ -1,0 +1,39 @@
+# ofirkai for Ghostty — https://github.com/ofirgall/ofirkai.nvim
+#
+# Install: copy this file to ~/.config/ghostty/themes/ofirkai (the theme name is
+# the file name, so keep it extensionless), then set `theme = ofirkai` in
+# ~/.config/ghostty/config.
+#
+# Every colour is a value from lua/ofirkai/design.lua. Two slots cannot be taken
+# verbatim, because ANSI has no room for them:
+#
+#   * The bright row (8-15) has no counterpart in the scheme, so each entry is
+#     its normal-row colour lifted 20% toward white. `grey` covers bright black.
+#   * Bright yellow is `orange` rather than a lighter `yellow`: orange carries
+#     too much of the scheme's character to leave unreachable, and it is the one
+#     accent with no ANSI slot of its own.
+#
+# ANSI palette
+palette = 0=#272720
+palette = 1=#f92672
+palette = 2=#a6e22e
+palette = 3=#e6db74
+palette = 4=#66d9ef
+palette = 5=#ae81ff
+palette = 6=#3ae0b4
+palette = 7=#f8f8f0
+palette = 8=#8f908a
+palette = 9=#fa518e
+palette = 10=#b8e858
+palette = 11=#fd971f
+palette = 12=#85e1f2
+palette = 13=#be9aff
+palette = 14=#61e6c3
+palette = 15=#f9f9f3
+
+background = #1f1f19
+foreground = #f8f8f0
+cursor-color = #fd971f
+cursor-text = #1f1f19
+selection-background = #46453a
+selection-foreground = #f8f8f0

--- a/extras/ghostty/ofirkai-darkblue
+++ b/extras/ghostty/ofirkai-darkblue
@@ -1,0 +1,42 @@
+# ofirkai dark_blue for Ghostty — https://github.com/ofirgall/ofirkai.nvim
+#
+# Install: copy this file to ~/.config/ghostty/themes/ofirkai-darkblue (the theme
+# name is the file name, so keep it extensionless), then set
+# `theme = ofirkai-darkblue` in ~/.config/ghostty/config.
+#
+# Colours come from lua/ofirkai/themes/dark_blue.lua, falling back to
+# lua/ofirkai/design.lua for anything that variant does not override. Slots that
+# are not a straight copy:
+#
+#   * The bright row (8-15) has no counterpart in the scheme, so each entry is
+#     its normal-row colour lifted 20% toward white. `grey` covers bright black.
+#   * Blue is `cursor_linenr_fg` (#909ef5). Unlike the default scheme, this
+#     variant does have a genuine blue, so `aqua` is free to be cyan.
+#   * Bright yellow is `orange` and bright cyan is `teal` — both carry too much
+#     of the scheme's character to leave unreachable, and neither has an ANSI
+#     slot of its own.
+#
+# ANSI palette
+palette = 0=#131a24
+palette = 1=#e5125e
+palette = 2=#9eda26
+palette = 3=#e1d66f
+palette = 4=#909ef5
+palette = 5=#a97cfa
+palette = 6=#58cbe1
+palette = 7=#d7d7d7
+palette = 8=#8f908a
+palette = 9=#ea417e
+palette = 10=#b1e151
+palette = 11=#f8921a
+palette = 12=#a6b1f7
+palette = 13=#ba96fb
+palette = 14=#3ae0b4
+palette = 15=#edede5
+
+background = #080c10
+foreground = #d7d7d7
+cursor-color = #909ef5
+cursor-text = #080c10
+selection-background = #14364e
+selection-foreground = #edede5


### PR DESCRIPTION
Ports both schemes to [Ghostty](https://ghostty.org), so the terminal around Neovim matches the colorscheme instead of approximating it:

- `extras/ghostty/ofirkai` — the default scheme, from `lua/ofirkai/design.lua`
- `extras/ghostty/ofirkai-darkblue` — the `dark_blue` theme, from `lua/ofirkai/themes/dark_blue.lua` falling back to `design.lua`

Both files are plain Ghostty config; the file name is the theme name, so installing is a copy into `~/.config/ghostty/themes/` and one line in the config. README gains a `## Terminals` section with those steps.

### Slots that are not a straight copy

ANSI has 16 slots and the scheme does not map onto them one-to-one, so three decisions were needed. Each is commented inline in the theme files:

| slot | choice | why |
| --- | --- | --- |
| bright row (8–15) | normal-row colour lifted 20% toward white; `grey` for bright black | the scheme has no brighter siblings to draw on |
| bright yellow | `orange` | orange carries a lot of the scheme's character and has no ANSI slot of its own |
| bright cyan (dark_blue) | `teal` | same reasoning as orange |
| blue (dark_blue) | `cursor_linenr_fg` `#909ef5` | unlike the default scheme, this variant has a genuine blue, which frees `aqua` to be cyan |

In the default scheme blue stays `aqua` `#66d9ef`, following the usual Monokai convention.

If you would rather have the bright row be literal lightened yellows/cyans and keep orange and teal out of ANSI, that is one line per file to change — happy to adjust.

### Notes

- No Lua touched, so `doc/` needs no regeneration.
- Both files verified with `ghostty +validate-config`.
- Screenshots to follow — opening this early for feedback on the mapping above, since that is the part worth disagreeing with.
